### PR TITLE
Update tracking events enum

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,19 @@ shipcloud:
     - gls_express_1000
     - gls_express_1200
     - ups_express_1200
+  tracking_events:
+    - awaits_pickup_by_receiver
+    - canceled
+    - delayed
+    - delivered
+    - destroyed
+    - exception
+    - not_delivered
+    - notification
+    - out_for_delivery
+    - picked_up
+    - transit
+    - unknown
 
 # Build settings
 markdown: kramdown

--- a/_includes/schemas/shipments_response.json
+++ b/_includes/schemas/shipments_response.json
@@ -1,9 +1,17 @@
 {% assign carriers = "" %}
 {% for carrier in site.shipcloud.supported_carriers %}
   {% capture new_carrier %}"{{carrier}}"|{% endcapture %}
-  {% assign carriers = carriers | append: new_carrier %}
+  {% assign carriers = carriers | append: new_carrier %}
 {% endfor %}
 {% assign carriers = carriers | split: '|' %}
+
+{% assign tracking_events = "" | split: ',' %}
+{% for event in site.shipcloud.tracking_events %}
+  {% capture new_event %}"{{event}}"{% endcapture %}
+  {% assign tracking_events = tracking_events | push: new_event %}
+{% endfor %}
+{% capture initial_status %}"label_created"{% endcapture %}
+{% assign tracking_events = tracking_events | push: initial_status %}
 
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
@@ -11,7 +19,7 @@
   "properties": {
     "carrier": {
       "type": "string",
-      "enum": [{{ carriers | sort | join: ', ' }}],
+      "enum": [{{ carriers | sort | join: ', ' }}],
       "description": "acronym of the carrier"
     },
     "carrier_tracking_no": {
@@ -70,7 +78,7 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": ["label_created", "picked_up", "delivered", "not_delivered", "transit", "exception", "out_for_delivery", "destroyed", "unknown", "canceled"],
+                  "enum": [{{ tracking_events | sort | join: ', ' }}],
                   "description": "key describing the status"
                 },
                 "details": {

--- a/_includes/schemas/shipments_response.json
+++ b/_includes/schemas/shipments_response.json
@@ -79,7 +79,8 @@
                 "status": {
                   "type": "string",
                   "enum": [{{ tracking_events | sort | join: ', ' }}],
-                  "description": "key describing the status"
+                  "description": "key describing the status",
+                  "default": {{ initial_status }}
                 },
                 "details": {
                   "type": "string",

--- a/_includes/schemas/trackers_response.json
+++ b/_includes/schemas/trackers_response.json
@@ -1,9 +1,17 @@
 {% assign carriers = "" %}
 {% for carrier in site.shipcloud.supported_carriers %}
   {% capture new_carrier %}"{{carrier}}"|{% endcapture %}
-  {% assign carriers = carriers | append: new_carrier %}
+  {% assign carriers = carriers | append: new_carrier %}
 {% endfor %}
 {% assign carriers = carriers | split: '|' %}
+
+{% assign tracking_events = "" | split: ',' %}
+{% for event in site.shipcloud.tracking_events %}
+  {% capture new_event %}"{{event}}"{% endcapture %}
+  {% assign tracking_events = tracking_events | push: new_event %}
+{% endfor %}
+{% capture initial_status %}"registered"{% endcapture %}
+{% assign tracker_statuses = tracking_events | push: initial_status %}
 
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
@@ -19,7 +27,7 @@
     },
     "status": {
       "type": "string",
-      "enum": ["registered", "label_created", "picked_up", "delivered", "not_delivered", "transit", "exception", "out_for_delivery", "destroyed", "unknown", "canceled"],
+      "enum": [{{ tracker_statuses | sort | join: ', ' }}],
       "description": "key describing the current status"
     },
     "created_at": {
@@ -52,7 +60,7 @@
     },
     "carrier": {
       "type": "string",
-      "enum": [{{ carriers | sort | join: ', ' }}],
+      "enum": [{{ carriers | sort | join: ', ' }}],
       "description": "acronym of the carrier the shipment was sent with"
     },
     "to": {
@@ -75,7 +83,7 @@
           },
           "status": {
             "type": "string",
-            "enum": ["registered", "label_created", "picked_up", "delivered", "not_delivered", "transit", "exception", "out_for_delivery", "destroyed", "unknown", "canceled"],
+            "enum": [{{ tracking_events | sort | join: ', ' }}],
             "description": "key describing the status"
           },
           "details": {

--- a/_includes/schemas/trackers_response.json
+++ b/_includes/schemas/trackers_response.json
@@ -84,7 +84,8 @@
           "status": {
             "type": "string",
             "enum": [{{ tracking_events | sort | join: ', ' }}],
-            "description": "key describing the status"
+            "description": "key describing the status",
+            "default": {{ initial_status }}
           },
           "details": {
             "type": "string",


### PR DESCRIPTION
Adds missing statuses to `Tracker` and `Shipment` schema.
Points to consider:

* The initial status of a Tracker is `registered`.
* The initial status of a shipment is `label_created`.