### PR TITLE
added access point delivery for UPS

### DIFF
--- a/API_CHANGELOG.html
+++ b/API_CHANGELOG.html
@@ -77,6 +77,17 @@ title: shipcloud api changelog
 </section>
 
 <section class="mb-l">
+  <h2 id="20210310---2021-03-10" class="mb-s">[20210310] - 2021-03-10</h2>
+  <h3>Added</h3>
+  <ul class="list-outside list-disc ml-m">
+    <li>
+      <a href="{{ site.baseurl }}/carriers/ups.html#ship-webservice---access-point-delivery">
+      Access point delivery</a> for UPS
+    </li>
+  </ul>
+</section>
+
+<section class="mb-l">
   <h2 id="20210217---2021-02-17" class="mb-s">[20210217] - 2021-02-17</h2>
   <h3>Added</h3>
   <ul class="list-outside list-disc ml-m">

--- a/_data/carriers/ups.json
+++ b/_data/carriers/ups.json
@@ -53,6 +53,10 @@
               "key": "saturday_delivery"
             },
             {
+              "display_name": "Access point notification",
+              "key": "ups_access_point_notification"
+            },
+            {
               "display_name": "Direct delivery only",
               "key": "ups_direct_delivery_only"
             },
@@ -83,6 +87,9 @@
             ]
           }],
           "misc": [{
+              "display_name": "Access point delivery",
+              "key": "access_point_delivery"
+            },{
               "display_name": "Cutoff times",
               "key": "cutoff_times"
             },

--- a/_includes/examples/carriers/ups/ship_webservice/additional_services/ups_access_point_notification.html
+++ b/_includes/examples/carriers/ups/ship_webservice/additional_services/ups_access_point_notification.html
@@ -1,0 +1,15 @@
+<h4 id="ship-webservice---ups-access-point-notification" class="text-blue">
+  Access point notification
+</h4>
+
+<div class="mt-m bg-grey-light border-t-4 border-grey-darker text-grey-darker rounded-b px-4 py-3 shadow-md my-2" role="alert">
+  <div class="flex">
+    <div>
+      <i class="fas fa-info-circle h-6 w-6 mr-4"></i>
+    </div>
+    <div>
+      The additional service can only be used in conjunction with
+      <a href="#ship-webservice---access-point-delivery">delivery to a UPS access point</a>.
+    </div>
+  </div>
+</div>

--- a/_includes/examples/carriers/ups/ship_webservice/misc/access_point_delivery.html
+++ b/_includes/examples/carriers/ups/ship_webservice/misc/access_point_delivery.html
@@ -1,0 +1,101 @@
+<h4 id="ship-webservice---access-point-delivery" class="text-blue">
+  Access point delivery
+</h4>
+
+<p>
+  When using UPS as a carrier it is possible to let shipments be delivered to a UPS access point.
+  This way recipients do not have to be at home for receiving their shipments but can collect them
+  from the access point at a later time.
+</p>
+
+<p class="mt-m">
+  <strong>Requirements:</strong>
+</p>
+<ul class="list-inside list-disc">
+  <li>
+    the recipients address has to be provided as you normally would using the
+    <code><em>to</em></code> attribute
+  </li>
+  <li>
+    you have to provide the exact address of the UPS access point using the
+    <code><em>drop_off_point</em></code> attribute
+  </li>
+  <li>
+    the attribute <code><em>drop_off_point.type</em></code> has to be
+    <code><em>parcel_shop</em></code>
+  </li>
+  <li>
+    you also have to use the additional service
+    <code><em>ups_access_point_notification</em></code>
+    (<a data-controller="toggle-element"
+      data-target="#ship_webservice_access_point_delivery_togglebox" aria-expanded="false"
+      aria-controls="collapseExample" class="cursor-pointer">see example</a>)
+  </li>
+</ul>
+
+<section class="shadow my-m">
+  <article class="border-b">
+    <div class="border-l-2 border-transparent">
+      {% include utils/toggle_element.html target="#ship_webservice_access_point_delivery_togglebox" link_text="Show example"%}
+      <div class="px-4 pb-2 text-grey-darkest hidden" id="ship_webservice_access_point_delivery_togglebox">
+        <div class="mt-m">
+{% highlight http %}
+POST https://api.shipcloud.io/v1/shipments
+{% endhighlight %}
+
+{% highlight json %}
+{
+  "from": {
+    "first_name": "Serge",
+    "last_name": "Sender",
+    "company": "Sender Corp.",
+    "street": "Sender Str.",
+    "street_no": "99",
+    "zip_code": "20148",
+    "city": "Hamburg",
+    "country": "DE"
+  },
+  "to": {
+    "first_name": "Roger",
+    "last_name": "Receiver",
+    "street": "Receiver Str.",
+    "street_no": "1",
+    "city": "Hamburg",
+    "zip_code": "20535",
+    "country": "DE"
+  },
+  "drop_off_point": {
+    "company": "The BlueYellowShirts Store",
+    "street": "Drop Off Str.",
+    "street_no": "1",
+    "city": "Hamburg",
+    "zip_code": "20457",
+    "country": "DE",
+    "type": "parcel_shop"
+  },
+  "package": {
+    "weight": 0.5,
+    "length": 20,
+    "width": 15,
+    "height": 5,
+    "type": "parcel"
+  },
+  "additional_services": [
+    {
+      "name": "ups_access_point_notification",
+      "properties": {
+        "email": "roger@receiver.inc",
+        "language": "DE"
+      }
+    }
+  ],
+  "carrier": "{{page.carrier}}",
+  "service": "standard",
+  "create_shipping_label": true
+}
+{% endhighlight %}
+        </div>
+      </div>
+    </div>
+  </article>
+</section>


### PR DESCRIPTION
This comes with a new additional service `ups_access_point_notification`
that can only be used when sending shipments to a UPS access point