### PR TITLE
DHL returns from GB

### DIFF
--- a/_includes/examples/carriers/dhl/v3/other_attributes/customs_declaration.html
+++ b/_includes/examples/carriers/dhl/v3/other_attributes/customs_declaration.html
@@ -9,6 +9,11 @@
 </p>
 
 <p class="mt-m">
+  If you are providing return shipments from Great Britain please also read our information about
+  <a href="#v3---returns-from-gb">returns from GB</a>.
+</p>
+
+<p class="mt-m">
   <strong>Requirements:</strong>
 </p>
 <ul class="list-inside list-disc">

--- a/_includes/examples/carriers/dhl/v3/services/returns.html
+++ b/_includes/examples/carriers/dhl/v3/services/returns.html
@@ -65,3 +65,29 @@ POST https://api.shipcloud.io/v1/shipments
     </div>
   </article>
 </section>
+
+<h5 id="v3---returns-from-gb" class="text-blue mt-m">
+  Returns from GB
+</h5>
+
+<p>
+  Since August 1, 2021 the carrier DHL requires data for a customs declaration to be send, when
+  creating return shipments from Great Britain.
+</p>
+
+<p class="mt-m">
+  <strong>Requirements:</strong>
+</p>
+<ul class="list-inside list-disc">
+  <li>only applicable for shipments from Great Britain to Germany</li>
+  <li>
+    you can specify the <code>customs_declaration.currency</code> as either <code>EUR</code> or
+    <code>GBP</code>
+  </li>
+  <li>
+    the <code>customs_declaration.contents_type</code> has to be <code>returned_goods</code>
+  </li>
+  <li>
+    labels can only be provided as DIN A5 pdf
+  </li>
+</ul>


### PR DESCRIPTION
added new information about return shipments from Great Britain, since DHL now requires customs declaration data to be transmitted