### PR TITLE
Fix typo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ group :jekyll_plugins do
   gem "jekyll-sitemap"
   gem "html-proofer", "~> 3.10.x"
 end
+
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     unicode-display_width (1.8.0)
+    webrick (1.7.0)
     yell (2.2.2)
 
 PLATFORMS
@@ -94,6 +95,7 @@ DEPENDENCIES
   kramdown (~> 2.1.x)
   liquid (~> 4.0.x)
   rake
+  webrick (~> 1.7)
 
 BUNDLED WITH
    2.1.4

--- a/downloads/api/oai/shipcloud_v1_oai3.json
+++ b/downloads/api/oai/shipcloud_v1_oai3.json
@@ -650,7 +650,7 @@
         }
       }
     },
-    "/manifest": {
+    "/manifests": {
       "post": {
         "description": "Create a manifest",
         "requestBody": {


### PR DESCRIPTION
We're fixing the typo `manifest` to `manifests`
Add gem `webrick`
[sc-14438](https://app.shortcut.com/shipcloud/story/14438/shipcloud-developer-portal-fix-typo)