### PR TITLE
Update label formats

### DIFF
--- a/_data/carriers/dhl_express.json
+++ b/_data/carriers/dhl_express.json
@@ -27,26 +27,58 @@
               "key": "one_day_early"
             }
           ],
-          "package_types": [{
-            "display_name": "Parcel",
-            "key": "parcel"
-          }],
-          "additional_services": [{
-            "display_name": "Saturday delivery",
-            "key": "saturday_delivery"
-          }],
-          "label_formats": [{
-            "pdf": [
-              {
-                "display_name": "DIN A5",
-                "key": "pdf_a5"
-              },
-              {
-                "display_name": "DIN A6",
-                "key": "pdf_a6"
-              }
-            ]
-          }],
+          "package_types": [
+            {
+              "display_name": "Parcel",
+              "key": "parcel"
+            }
+          ],
+          "additional_services": [
+            {
+              "display_name": "Saturday delivery",
+              "key": "saturday_delivery"
+            }
+          ],
+          "label_formats": [
+            {
+              "pdf": [
+                {
+                  "display_name": "DIN A5",
+                  "key": "pdf_a5"
+                },
+                {
+                  "display_name": "DIN A6",
+                  "key": "pdf_a6"
+                }
+              ],
+              "zpl": [
+                {
+                  "display_name": "ZPL2 a6 203dpi",
+                  "key": "zpl2_a6_203dpi"
+                },
+                {
+                  "display_name": "ZPL2 a6 300dpi",
+                  "key": "zpl2_a6_300dpi"
+                },
+                {
+                  "display_name": "ZPL2 4x6in 203dpi",
+                  "key": "zpl2_4x6in_203dpi"
+                },
+                {
+                  "display_name": "ZPL2 4x6in 300dpi",
+                  "key": "zpl2_4x6in_300dpi"
+                },
+                {
+                  "display_name": "ZPL2 4x8in 203dpi",
+                  "key": "zpl2_4x8in_203dpi"
+                },
+                {
+                  "display_name": "ZPL2 4x8in 300dpi",
+                  "key": "zpl2_4x8in_300dpi"
+                }
+              ]
+            }
+          ],
           "field_lengths": {
             "shipments": {
               "company": "2 - 35 characters",

--- a/_data/carriers/dpag.json
+++ b/_data/carriers/dpag.json
@@ -7,7 +7,8 @@
       "display_name": "DPAG one click for app v3",
       "implementations": {
         "shipcloud": {
-          "services": [{
+          "services": [
+            {
               "display_name": "Standard",
               "key": "standard"
             },
@@ -24,7 +25,8 @@
               "key": "dpag_warenpost_signature"
             }
           ],
-          "package_types": [{
+          "package_types": [
+            {
               "display_name": "Letter",
               "key": "letter"
             },
@@ -37,26 +39,44 @@
               "key": "books"
             }
           ],
-          "other_attributes": [{
-            "display_name": "Customs declaration",
-            "key": "customs_declaration"
-          },
-          {
-            "display_name": "Packstation",
-            "key": "packstation"
-          }],
-          "label_formats": [{
-            "pdf": [
-              {
-                "display_name": "DIN A5",
-                "key": "pdf_a5"
-              },
-              {
-                "display_name": "DIN A6",
-                "key": "pdf_a6"
-              }
-            ]
-          }]
+          "other_attributes": [
+            {
+              "display_name": "Customs declaration",
+              "key": "customs_declaration"
+            },
+            {
+              "display_name": "Packstation",
+              "key": "packstation"
+            }
+          ],
+          "label_formats": [
+            {
+              "pdf": [
+                {
+                  "display_name": "DIN A5",
+                  "key": "pdf_a5"
+                },
+                {
+                  "display_name": "DIN A6",
+                  "key": "pdf_a6"
+                }
+              ],
+              "zpl": [
+                {
+                  "display_name": "ZPL2 4x6in 203dpi",
+                  "key": "zpl2_4x6in_203dpi"
+                },
+                {
+                  "display_name": "ZPL2 4x6in 300dpi",
+                  "key": "zpl2_4x6in_300dpi"
+                },
+                {
+                  "display_name": "ZPL2 4x6in 300dpi td",
+                  "key": "zpl2_4x6in_203dpi_td"
+                }
+              ]
+            }
+          ]
         }
       }
     }

--- a/_data/carriers/dpd.json
+++ b/_data/carriers/dpd.json
@@ -7,7 +7,8 @@
       "display_name": "Shipment Service V4.3",
       "implementations": {
         "shipcloud": {
-          "services": [{
+          "services": [
+            {
               "display_name": "Standard",
               "key": "standard"
             },
@@ -24,7 +25,8 @@
               "key": "one_day_early"
             }
           ],
-          "package_types": [{
+          "package_types": [
+            {
               "display_name": "Parcel",
               "key": "parcel"
             },
@@ -33,7 +35,8 @@
               "key": "parcel_letter"
             }
           ],
-          "additional_services": [{
+          "additional_services": [
+            {
               "display_name": "Drop authorization",
               "key": "drop_authorization"
             },
@@ -60,18 +63,34 @@
               "key": "trackers"
             }
           ],
-          "label_formats": [{
-            "pdf": [
-              {
-                "display_name": "DIN A5",
-                "key": "pdf_a5"
-              },
-              {
-                "display_name": "DIN A6",
-                "key": "pdf_a6"
-              }
-            ]
-          }],
+          "label_formats": [
+            {
+              "pdf": [
+                {
+                  "display_name": "DIN A5",
+                  "key": "pdf_a5"
+                },
+                {
+                  "display_name": "DIN A6",
+                  "key": "pdf_a6"
+                }
+              ],
+              "zpl": [
+                {
+                  "display_name": "ZPL2 4x6in 203dpi",
+                  "key": "zpl2_4x6in_203dpi"
+                },
+                {
+                  "display_name": "ZPL2 4x6in 300dpi",
+                  "key": "zpl2_4x6in_300dpi"
+                },
+                {
+                  "display_name": "ZPL2 4x6in 300dpi td",
+                  "key": "zpl2_4x6in_203dpi_td"
+                }
+              ]
+            }
+          ],
           "field_lengths": {
             "shipments": {
               "company": "1 - 35 characters",


### PR DESCRIPTION
We're updating the label formats for a few carriers
[sc-15563](https://app.shortcut.com/shipcloud/story/15563/dev-doku-label-format-aktualisieren-für-alle-carrier)