### PR TITLE
Wide layout for OpenAPI spec template

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ If you want to run our developer portal locally you can do it by following these
 ```console
 ~ $ git clone git@github.com:shipcloud/shipcloud-developer-portal.git
 ~ $ cd shipcloud-developer-portal
-~ $ bundle install
-~/shipcloud-developer-portal $ bundle exec rake serve
+~/shipcloud-developer-portal $ bundle install
+~/shipcloud-developer-portal $ bundle exec rake
 ```
 
 ## Contributing

--- a/_layouts/default_wide.html
+++ b/_layouts/default_wide.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+
+  {% include head.html %}
+
+  <body class="bg-white" data-offset="90">
+    {% include google_tag_manager_body.html %}
+
+    {% include header.html %}
+
+    <div class="DocSearch-content">
+      {% include navs/main.html %}
+      <div class="flex ml-56 pt-16">
+        <div class="block w-full">
+          <div class="p-l pb-xl">
+            {{ content }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {% include footer.html %}
+
+    <script src="{{ "/assets/js/utils.js" | prepend: site.baseurl }}"></script>
+    {% include js_files.html %}
+  </body>
+</html>

--- a/swagger-ui/index.html
+++ b/swagger-ui/index.html
@@ -1,6 +1,6 @@
 ---
-title: SwaggerUI
-layout: default
+title: shipcloud OpenAPI Spec
+layout: default_wide
 nav: openapi
 ---
 


### PR DESCRIPTION
With the current two column layout, the OpenAPI spec swagger UI is too crammed to be able to read it. Tailwind allows us to set page specific layouts, though, so we provide a new wide layout without the right blue column and render the swagger UI with it.