### PR TITLE
Fix the terms and conditions link

### DIFF
--- a/downloads/api/oai/shipcloud_v1_oai3.json
+++ b/downloads/api/oai/shipcloud_v1_oai3.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "shipcloud.io API",
     "description": "Everything about the shipcloud api",
-    "termsOfService": "https://www.shipcloud.io/en/terms_and_conditions",
+    "termsOfService": "https://www.shipcloud.io/en/terms-and-conditions",
     "contact": {
       "name": "Developer Support",
       "email": "developers@shipcloud.io"


### PR DESCRIPTION
The correct link uses dashes instead of underscores.