### PR TITLE
Fixes spinner icon in 400 response schema

### DIFF
--- a/downloads/api/oai/shipcloud_v1_oai3.json
+++ b/downloads/api/oai/shipcloud_v1_oai3.json
@@ -6226,7 +6226,10 @@
               "properties": {
                 "errors": {
                   "type": "array",
-                  "description": "Strings that describe, what has gone wrong. We're tunnelling error responses from the carriers. When this is the case, we try to prefix an error with 'The carrier {xyz} returned the following error:'"
+                  "items": {
+                    "description": "Strings that describe, what has gone wrong. We're tunnelling error responses from the carriers. When this is the case, we try to prefix an error with 'The carrier {xyz} returned the following error:'",
+                    "type": "string"
+                  }
                 }
               }
             },


### PR DESCRIPTION
We define an array in the response body, but did not specify its items' type.

[sc-17555](https://app.shortcut.com/shipcloud/story/17555)