### PR TITLE
Add metadata to trackers schema

### DIFF
--- a/_includes/schemas/trackers_request.json
+++ b/_includes/schemas/trackers_request.json
@@ -33,6 +33,11 @@
     "notification_email": {
       "type": "string",
       "description": "email address that we should notify once there's an update for this shipment"
+    },
+    "metadata": {
+      "type": "object",
+      "description": "here you can save additional data that you want to be associated with the shipment. Any combination of key-value pairs is possible",
+      "additionalProperties": true
     }
   },
   "required": ["carrier_tracking_no", "carrier"],

--- a/_includes/schemas/trackers_response.json
+++ b/_includes/schemas/trackers_response.json
@@ -94,6 +94,10 @@
         "required": ["timestamp", "location", "status", "details"],
         "additionalProperties": false
       }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "additional data associated with the shipment"
     }
   },
   "required": ["id", "carrier_tracking_no", "status", "created_at", "tracking_status_updated_at", "last_polling_at", "next_polling_at", "shipment_id", "carrier"],


### PR DESCRIPTION
Shipments have an attribute called metadata where customers can give us any kind of data they want as json.

We now want to allow this for Trackers as well.
Trackers is an endpoint for the send-core to create shipments that we do not create at the carrier but rather only have in our system to track them. 

Internally these are not a separate resource but rather a shipment with shipment_type: tracking_only.

To enable the use of metadata for those we need to add the functionality to the controller and builder for tracking_only shipments.

A customer should be able to create a Shipment with type tracking_only via the trackers endpoint that has metadata saved to it

Related PR: https://github.com/shipcloud/shipcloud/pull/9409

[sc-29308](https://app.shortcut.com/shipcloud/story/29308/allow-metadata-for-tracking-only-shipments)