### PR TITLE
Remove delivery location delivery details

### DIFF
--- a/_includes/examples/carriers/dhl/v3/carrier_specifics/general_information.html
+++ b/_includes/examples/carriers/dhl/v3/carrier_specifics/general_information.html
@@ -19,29 +19,3 @@
   outbound shipments and not for returns. There you still have to provide both entries when creating
   a shipping label.
 </p>
-
-<h5 id="v3---additional-delivery-details" class="text-blue mt-m">
-  Additional delivery details in tracking events
-</h5>
-
-<p>
-  Sometimes DHL provides additional information regarding a delivery that has been made. For example
-  when the shipments has been handed over to a next door neighbor or has been placed at a drop off
-  location. In those cases we're returning these additional delivery details as part of the
-  corresponding tracking event.
-</p>
-
-{% highlight json %}
-{
-  "timestamp": "2013-05-26T16:55:24+02:00",
-  "location": "Hamburg, Deutschland",
-  "status": "delivered",
-  "details": "Die Sendung wurde erfolgreich zugestellt.",
-  "delivery_details": {
-    "description": "Wunschort",
-    "name": "Wunschort (Ablagevertrag)",
-    "addressline1": "St. Annenufer 5",
-    "addressline2": "20457 Hamburg"
-  }
-}
-{% endhighlight %}

--- a/downloads/api/oai/shipcloud_v1_oai3.json
+++ b/downloads/api/oai/shipcloud_v1_oai3.json
@@ -4023,13 +4023,7 @@
                   "location": "Hamburg, Deutschland",
                   "status": "delivered",
                   "details": "Die Sendung wurde erfolgreich zugestellt.",
-                  "id": "ttzisojr-1phm-gcq0-jvch-hbdhd48scsuf",
-                  "delivery_details": {
-                    "description": "Wunschort",
-                    "name": "Wunschort (Ablagevertrag)",
-                    "addressline1": "St. Annenufer 5",
-                    "addressline2": "20457 Hamburg"
-                  }
+                  "id": "ttzisojr-1phm-gcq0-jvch-hbdhd48scsuf"
                 },
                 {
                   "timestamp": "2024-08-29T08:12:12+02:00",
@@ -5219,28 +5213,6 @@
                     "details": {
                       "type": "string",
                       "description": "Message the carrier sent to describe the package status"
-                    },
-                    "delivery_details": {
-                      "type": "object",
-                      "description": "Additional details about where or with whom the shipment has been left",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "description": "An associated name of the person or place, where the package was dropped off"
-                        },
-                        "description": {
-                          "type": "string",
-                          "description": "An additional description of where the package was dropped off"
-                        },
-                        "addressline1": {
-                          "type": "string",
-                          "description": "First line of the address where the package was dropped off"
-                        },
-                        "addressline2": {
-                          "type": "string",
-                          "description": "Second line of the address where the package was dropped off"
-                        }
-                      }
                     }
                   },
                   "required": [


### PR DESCRIPTION
https://app.shortcut.com/shipcloud/story/39253/remove-delivery-location-delivery-details-from-api-docs